### PR TITLE
Changed 'cider-interaction' to 'cider-find'

### DIFF
--- a/re-jump.el
+++ b/re-jump.el
@@ -28,7 +28,7 @@
 (require 'cider-resolve)
 (require 'cider-client)
 (require 'cider-common)
-(require 'cider-interaction)
+(require 'cider-find)
 (require 'clojure-mode)
 
 (defun re-frame-jump-to-reg ()


### PR DESCRIPTION
'cider-interaction' no longer exists.  `cider-find-ns` can now be found in 'cider-find'.